### PR TITLE
Photo esup sgc impl

### DIFF
--- a/src/main/java/fr/univlorraine/mondossierweb/config/SpringConfig.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/config/SpringConfig.java
@@ -146,6 +146,9 @@ public class SpringConfig {
 			lattributes.add(environment.getProperty("ldap.uid.attribute"));
 		}
 		lattributes.add("mail");
+		if(environment.getProperty("context.param.esupsgc.urlphoto")!=null) {
+			lattributes.add("eduPersonPrincipalName");
+		}
 		lattributes.add(PropertyUtils.getAttributLdapEtudiant());
 		lattributes.add(PropertyUtils.getAttributLdapCodEtu());
 		if(StringUtils.hasText(PropertyUtils.getAttributGroupeLdap())){

--- a/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
@@ -1,0 +1,121 @@
+/**
+ *
+ *  ESUP-Portail MONDOSSIERWEB - Copyright (c) 2016 ESUP-Portail consortium
+ *
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ *
+ */
+package fr.univlorraine.mondossierweb.photo;
+
+import java.security.Key;
+import java.util.Calendar;
+import java.util.Date;
+
+import javax.annotation.Resource;
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+
+import fr.univlorraine.mondossierweb.utils.PropertyUtils;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.binary.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.ldap.search.LdapUserSearch;
+import org.springframework.stereotype.Component;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.RestTemplate;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.interfaces.DecodedJWT;
+
+import fr.univlorraine.mondossierweb.converters.LoginCodeEtudiantConverterInterface;
+import fr.univlorraine.mondossierweb.utils.Utils;
+
+@Component(value="photoEsupSgc")
+public class PhotoEsupSgcImpl implements IPhoto {
+
+	private static final String UTF_8 = "UTF-8";
+
+	private Logger LOG = LoggerFactory.getLogger(PhotoUnivLorraineImplV2.class);
+
+	@Value("${context.param.esupsgc.urlphoto}")
+	private String esupSgcPhotoUrl;
+
+	@Resource
+	private transient LdapUserSearch ldapEtudiantSearch;
+
+	RestTemplate rt = new RestTemplate();
+
+	@Override
+	public String getUrlPhoto(String cod_ind, String cod_etu, boolean isUtilisateurEnseignant, String loginUser) {
+		String photoAsBase64 = getPhotoAsBase64(cod_etu);
+		return String.format("%s/png;base64,%s", Utils.DATA_IMAGE, photoAsBase64);
+	}
+
+	@Override
+	public String getUrlPhotoTrombinoscopePdf(String cod_ind, String cod_etu, boolean isUtilisateurEnseignant, String loginUser) {
+		return getUrlPhoto(cod_ind, cod_etu, isUtilisateurEnseignant, loginUser);
+	}
+
+	@Override
+	public boolean isOperationnel() {
+		return esupSgcPhotoUrl != null;
+	}
+
+	byte[] getPhoto(String cod_etu) {
+		String eppn = getEppnFromCodEtu(cod_etu);
+		String url = String.format("%s/%s/photo", esupSgcPhotoUrl, eppn);
+		LOG.debug("GET PHOTO : " + url);
+		try {
+			ResponseEntity<byte[]> response = rt.getForEntity(url, byte[].class);
+			return response.getBody();
+		} catch(HttpClientErrorException he) { 
+			LOG.warn("Récupération de la photo de "+eppn+" en erreur Erreur HTTP "+he.getStatusCode());
+			return he.getResponseBodyAsByteArray();
+		} catch (Exception e) {
+			LOG.error("Une erreur est survenue lors de la récupération de la photo de "+eppn,e);
+		}
+		return null;
+	}
+
+	String getPhotoAsBase64(String cod_etu) {
+		byte[] photo = getPhoto(cod_etu);
+		if(photo!=null) {
+			return StringUtils.newStringUtf8(Base64.encodeBase64(photo, false));
+		}
+		return null;
+	}
+
+	String getEppnFromCodEtu(String codetu) {
+		String[] vals= ldapEtudiantSearch.searchForUser(codetu).getStringAttributes("eduPersonPrincipalName");
+		if(vals!=null){
+			LOG.debug("login via codetu pour "+codetu+" => "+vals[0]);
+			return vals[0];
+		} else {
+			LOG.warn("No eduPersonPrincipalName  in LDAP for " + codetu);
+		}
+		return null;
+	}
+
+
+}

--- a/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
@@ -84,7 +84,7 @@ public class PhotoEsupSgcImpl implements IPhoto {
 
 	byte[] getPhoto(String cod_etu) {
 		String eppn = getEppnFromCodEtu(cod_etu);
-		String url = String.format("%s/%s/photo", esupSgcPhotoUrl, eppn);
+		String url = String.format(esupSgcPhotoUrl, eppn);
 		LOG.debug("GET PHOTO : " + url);
 		try {
 			ResponseEntity<byte[]> response = rt.getForEntity(url, byte[].class);


### PR DESCRIPTION
Proposition d'une implémentation permettant à esup-mdw de récupérer les photos d'un [esup-sgc](https://github.com/EsupPortail/esup-sgc).
L'exploitant qui souhaiterait une telle mise en place pourrait ainsi configurer le context.xml en configurant par exemple : 
```
	<Parameter name="serveurphoto.implementation" value="photoEsupSgc" />
	<Parameter name="context.param.esupsgc.urlphoto"
			   value="https://esup-sgc.mon-univ.fr/wsrest/photo/%s/restrictedPhoto"/>
```
L'URL en restrictedPhoto permet côté esup-sgc de prendre en compte l'acceptation par l'étudiant de la diffusion de sa photo, suivant l'usage et les spécificités rgpd, l'établissement peut aussi ne pas prendre en compte cela en mettant simplement en url
[https://esup-sgc.mon-univ.fr/wsrest/photo/%s/photo]()

A noter que %s est remplacé par l'eppn de l'étudiant récupéré du ldap (d'où la modification de SpringConfig.java)
En utilisant la facilité donnée par l'insertion des images en base64 dans le html, l'implémentation proposée ici est de fait : 
* très simple
* générique et pourrait s'adapter à d'autres services qu'esup-sgc

Elle est par contre :
* moins performante que via l'implémentation PhotoUnivLorraineImplV2.java (usage d'url externe pour les images en html)
* moins souple du point de vue sécurité que  PhotoUnivLorraineImplV2.java qui via l'usage de jwt permet de propager l'authentification au web-service proposant les photos et permet donc l'accès ou non à certaines photos suivant les droits de l'utilisateur (enseignant) lui-même dans le serveur de photo.

Ici en effet, la sécurité côté esup-sgc permet simplement de dire que l'application esup-mdw a accès en tant que serveur au ws de photos d'esup-sgc et que les permissions d'accès aux photos correspondent à une même et unique règle pour l'ensemble des enseignants (avec prise en compte de l'acceptation de la diffusion de la photo par l'étudiant côté esup-sgc, cf ci-avant).

Côté esup-sgc, ce contrôle d'accès au web-service des photos se fait via la  propriété de accessRestrictionWSRestPhoto de security.properties (côté esup-sgc donc) où on propose par défaut de lister les IPs via des expressions type `hasIpAddress('127.0.0.1') or hasIpAddress('0:0:0:0:0:0:0:1') or ...`
