### PR TITLE
Debug : configuration de param.esupsgc.urlphoto non obligatoire

### DIFF
--- a/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
@@ -58,7 +58,7 @@ public class PhotoEsupSgcImpl implements IPhoto {
 
 	private Logger LOG = LoggerFactory.getLogger(PhotoUnivLorraineImplV2.class);
 
-	@Value("${param.esupsgc.urlphoto}")
+	@Value("${param.esupsgc.urlphoto:}")
 	private String esupSgcPhotoUrl;
 
 	@Resource


### PR DESCRIPTION
Sans cela et suite au PR #55 , on a l'erreur suivante au démarrage (si param.esupsgc.urlphoto n'est pas renseigné)
```
 Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'param.esupsgc.urlphoto' in value "${param.esupsgc.urlphoto}"
```
Merci encore, désolé de ne pas avoir fait attention à cela dès le départ.