### PR TITLE
Debug : fixe PhotoEsupSgcImpl - récupération eppn à null quand pas d'entrée ldap pour codeEtu correspondant

### DIFF
--- a/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
+++ b/src/main/java/fr/univlorraine/mondossierweb/photo/PhotoEsupSgcImpl.java
@@ -107,14 +107,19 @@ public class PhotoEsupSgcImpl implements IPhoto {
 	}
 
 	String getEppnFromCodEtu(String codetu) {
-		String[] vals= ldapEtudiantSearch.searchForUser(codetu).getStringAttributes("eduPersonPrincipalName");
-		if(vals!=null){
-			LOG.debug("login via codetu pour "+codetu+" => "+vals[0]);
-			return vals[0];
-		} else {
-			LOG.warn("No eduPersonPrincipalName  in LDAP for " + codetu);
+		try {
+			String[] vals = ldapEtudiantSearch.searchForUser(codetu).getStringAttributes("eduPersonPrincipalName");
+			if (vals != null) {
+				LOG.debug("login via codetu pour " + codetu + " => " + vals[0]);
+				return vals[0];
+			} else {
+				LOG.warn("No eduPersonPrincipalName  in LDAP for " + codetu);
+			}
+			return null;
+		} catch (Exception e) {
+			LOG.error("probleme de récupération de l'eppn depuis le codetu via le ldap. ",e);
+			return null;
 		}
-		return null;
 	}
 
 


### PR DESCRIPTION
Petit ajustement à nouveau ; reprend la façon de faire donnée dans EmailConverterImplLdap.getMail 

CF https://github.com/EsupPortail/esup-mdw/blob/0f21e291135f2aee35c0609bdab08b39d9d060d7/src/main/java/fr/univlorraine/mondossierweb/converters/EmailConverterImplLdap.java#L56

-> pas d'entrée dans le ldap -> log en erreur -> retourne null -> esup-sgc renverra une photo en 404 (avatar avec point d'interrogation).
